### PR TITLE
[Feature] 회원가입 시 이메일 인증

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -26,6 +26,7 @@ dependencies {
 	//implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation:'
+	implementation 'org.springframework.boot:spring-boot-starter-mail'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'

--- a/src/main/java/com/eunsunzzang/posting/error/errorcode/AuthErrorCode.java
+++ b/src/main/java/com/eunsunzzang/posting/error/errorcode/AuthErrorCode.java
@@ -7,7 +7,9 @@ import org.springframework.http.HttpStatus;
 @Getter
 @RequiredArgsConstructor
 public enum AuthErrorCode implements ErrorCode {
-    EMAIL_DUPLICATE(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일 입니다.");
+    EMAIL_DUPLICATE(HttpStatus.BAD_REQUEST, "이미 존재하는 이메일 입니다."),
+    EMAIL_NOT_FOUND(HttpStatus.NOT_FOUND, "존재하지 않는 이메일 입니다."),
+    AUTH_CODE_ERROR(HttpStatus.BAD_REQUEST,"잘못된 인증 코드 입니다.");
 
     private final HttpStatus httpStatus;
     private final String errorMessage;

--- a/src/main/java/com/eunsunzzang/posting/member/Member.java
+++ b/src/main/java/com/eunsunzzang/posting/member/Member.java
@@ -1,10 +1,7 @@
 package com.eunsunzzang.posting.member;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.time.LocalDateTime;
 
@@ -12,6 +9,7 @@ import java.time.LocalDateTime;
 @AllArgsConstructor
 @Entity
 @Getter
+@Setter
 @Builder
 public class Member {
 
@@ -38,7 +36,7 @@ public class Member {
    //@Column(nullable = false, length=30)
     LocalDateTime emailAuthDt;
 
-    //@Enumerated(EnumType.STRING)
+    @Enumerated(EnumType.STRING)
     EmailAuthStatus emailAuthStatus;
 
     @Enumerated(EnumType.STRING)
@@ -46,9 +44,4 @@ public class Member {
 
     @Enumerated(EnumType.STRING)
     MemberStatus status;
-
-    // 회원 가입 시 권한 부여
-    public void addUserAuthority() {
-        this.role = MemberRole.ROLE_USER;
-    }
 }

--- a/src/main/java/com/eunsunzzang/posting/member/controller/MemberController.java
+++ b/src/main/java/com/eunsunzzang/posting/member/controller/MemberController.java
@@ -1,5 +1,7 @@
 package com.eunsunzzang.posting.member.controller;
 
+import com.eunsunzzang.posting.member.Member;
+import com.eunsunzzang.posting.member.dto.EmailAuthDto;
 import com.eunsunzzang.posting.member.dto.MemberSignUpDto;
 import com.eunsunzzang.posting.member.service.MemberService;
 import jakarta.validation.Valid;
@@ -15,9 +17,21 @@ public class MemberController {
 
     private final MemberService memberService;
 
+    /**
+     * 회원가입
+     * */
     @PostMapping("/signup")
     @ResponseStatus(HttpStatus.OK)
     public void signUp(@Valid @RequestBody MemberSignUpDto memberSignUpDto) throws Exception {
         memberService.signUp(memberSignUpDto);
+    }
+
+    /**
+     * 이메일 인증
+     * */
+    @PostMapping("/email-auth")
+    @ResponseStatus(HttpStatus.OK)
+    public void emailAuth(@RequestBody EmailAuthDto emailAuthDto) throws Exception{
+        memberService.emailAuth(emailAuthDto);
     }
 }

--- a/src/main/java/com/eunsunzzang/posting/member/dto/EmailAuthDto.java
+++ b/src/main/java/com/eunsunzzang/posting/member/dto/EmailAuthDto.java
@@ -1,0 +1,7 @@
+package com.eunsunzzang.posting.member.dto;
+
+public record EmailAuthDto(
+        String email,
+
+        String key) {
+}

--- a/src/main/java/com/eunsunzzang/posting/member/dto/MemberSignUpDto.java
+++ b/src/main/java/com/eunsunzzang/posting/member/dto/MemberSignUpDto.java
@@ -15,6 +15,10 @@ public record MemberSignUpDto(
         String password) {
 
     public Member toEntity() {
-        return Member.builder().name(name).email(email).password(password).build();
+        return Member.builder()
+                .name(name)
+                .email(email)
+                .password(password)
+                .build();
     }
 }

--- a/src/main/java/com/eunsunzzang/posting/member/service/MemberService.java
+++ b/src/main/java/com/eunsunzzang/posting/member/service/MemberService.java
@@ -1,10 +1,17 @@
 package com.eunsunzzang.posting.member.service;
 
+import com.eunsunzzang.posting.member.Member;
 import com.eunsunzzang.posting.member.dto.MemberSignUpDto;
 
 public interface MemberService {
-    /*
-    *회원가입
-     */
+
+    /**
+     * 회원가입
+     * */
     void signUp(MemberSignUpDto memberSignUpDto) throws Exception;
+
+    /**
+     * 이메일 인증
+     * */
+    void emailAuth(Member member) throws Exception;
 }

--- a/src/main/java/com/eunsunzzang/posting/member/service/MemberService.java
+++ b/src/main/java/com/eunsunzzang/posting/member/service/MemberService.java
@@ -1,6 +1,7 @@
 package com.eunsunzzang.posting.member.service;
 
 import com.eunsunzzang.posting.member.Member;
+import com.eunsunzzang.posting.member.dto.EmailAuthDto;
 import com.eunsunzzang.posting.member.dto.MemberSignUpDto;
 
 public interface MemberService {
@@ -13,5 +14,5 @@ public interface MemberService {
     /**
      * 이메일 인증
      * */
-    void emailAuth(Member member) throws Exception;
+    void emailAuth(EmailAuthDto emailAuthDto) throws Exception;
 }

--- a/src/main/java/com/eunsunzzang/posting/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/eunsunzzang/posting/member/service/MemberServiceImpl.java
@@ -24,7 +24,6 @@ import java.util.UUID;
 public class MemberServiceImpl implements MemberService{
 
     private final MemberRepository memberRepository;
-    private int tmpNum = 123;
 
     private final JavaMailSender mailSender;
 
@@ -34,13 +33,15 @@ public class MemberServiceImpl implements MemberService{
     @Override
     public void signUp(MemberSignUpDto memberSignUpDto) throws Exception {
         Member member = memberSignUpDto.toEntity();
-        member.setRole(MemberRole.ROLE_USER);
-        member.setEmailAuthStatus(EmailAuthStatus.VERIFICATION_ING);
-        member.setEmailAuthKey(UUID.randomUUID().toString());
 
         if(memberRepository.findByEmail(memberSignUpDto.email()).isPresent()){
             throw new AuthException(AuthErrorCode.EMAIL_DUPLICATE);
         }
+
+        member.setRole(MemberRole.ROLE_USER);
+        member.setEmailAuthStatus(EmailAuthStatus.VERIFICATION_ING);
+        member.setEmailAuthKey(UUID.randomUUID().toString());
+
         emailSend(member);
         memberRepository.save(member);
     }

--- a/src/main/java/com/eunsunzzang/posting/member/service/MemberServiceImpl.java
+++ b/src/main/java/com/eunsunzzang/posting/member/service/MemberServiceImpl.java
@@ -2,11 +2,16 @@ package com.eunsunzzang.posting.member.service;
 
 import com.eunsunzzang.posting.error.errorcode.AuthErrorCode;
 import com.eunsunzzang.posting.error.exception.AuthException;
+import com.eunsunzzang.posting.member.EmailAuthStatus;
 import com.eunsunzzang.posting.member.Member;
+import com.eunsunzzang.posting.member.MemberRole;
 import com.eunsunzzang.posting.member.dto.MemberSignUpDto;
 import com.eunsunzzang.posting.member.repository.MemberRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.mail.SimpleMailMessage;
+import org.springframework.mail.javamail.JavaMailSender;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 
 
@@ -16,16 +21,44 @@ import org.springframework.stereotype.Service;
 public class MemberServiceImpl implements MemberService{
 
     private final MemberRepository memberRepository;
+    private int tmpNum = 123;
 
+    private final JavaMailSender mailSender;
+
+    /**
+     * 회원가입
+     * */
     @Override
     public void signUp(MemberSignUpDto memberSignUpDto) throws Exception {
         Member member = memberSignUpDto.toEntity();
-        member.addUserAuthority();
+        member.setRole(MemberRole.ROLE_USER);
+        member.setEmailAuthStatus(EmailAuthStatus.VERIFICATION_ING);
 
         if(memberRepository.findByEmail(memberSignUpDto.email()).isPresent()){
             throw new AuthException(AuthErrorCode.EMAIL_DUPLICATE);
         }
-
+        emailSend(member);
         memberRepository.save(member);
+    }
+
+    /**
+     * 이메일 인증코드 전송
+     * */
+    public void emailSend(Member member) throws Exception {
+        SimpleMailMessage message = new SimpleMailMessage();
+        message.setText("\n인증번호는 " + tmpNum + "입니다");
+        message.setSubject("이메일 인증");
+        message.setTo(member.getEmail());
+
+        mailSender.send(message);
+    }
+
+    /**
+     * 이메일 인증
+     * */
+    @Override
+    @Async
+    public void emailAuth(Member member) throws Exception {
+
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,7 +3,7 @@ spring:
     url: jdbc:mariadb://127.0.0.1:3306/zzangzzang
     driver-class-name: org.mariadb.jdbc.Driver
     username: root
-    password: root
+    password: 
 
   jpa:
     generate-ddl: true
@@ -11,3 +11,20 @@ spring:
       ddl-auto: create
     show-sql: true
     database-platform: org.hibernate.dialect.MariaDBDialect
+
+  mail:
+    # Google smtp server 사용
+    host: smtp.gmail.com
+    port: 587
+    username: eunsun5460@gmail.com
+    password:
+    properties:
+      mail:
+        smtp:
+          starttls:
+            enable: true
+            required: true
+          auth: true
+          connectiontimeout: 5000
+          timeout: 5000
+          writetimeout: 5000

--- a/src/test/java/com/eunsunzzang/posting/member/service/MemberServiceTest.java
+++ b/src/test/java/com/eunsunzzang/posting/member/service/MemberServiceTest.java
@@ -1,5 +1,6 @@
 package com.eunsunzzang.posting.member.service;
 
+import com.eunsunzzang.posting.error.errorcode.AuthErrorCode;
 import com.eunsunzzang.posting.member.Member;
 import com.eunsunzzang.posting.member.MemberRole;
 import com.eunsunzzang.posting.member.dto.MemberSignUpDto;
@@ -74,7 +75,7 @@ class MemberServiceTest {
 
         //when, then
         assertThat(assertThrows(Exception.class,
-                () -> memberService.signUp(memberSignUpDto)).getMessage()).isEqualTo("이미 존재하는 이메일입니다.");
+                () -> memberService.signUp(memberSignUpDto)).getMessage()).isEqualTo(AuthErrorCode.EMAIL_DUPLICATE.getErrorMessage());
     }
 
 }


### PR DESCRIPTION
#5 
## Background 
이메일 인증 코드를 통해 가입하고자 하는 사용자의 이메일을 검증하였다.

## Change
기존의 회원가입 로직에 이메일 인증을 통해 가입을 완료시키는 1step을 더 추가하였다.

## Test
`MemberControllerTest` test code 를 통해 확인하였다.
이메일 검증 키와 이메일을 통해 post api 실행 확인

## Discuss
- 소아가 준 피드백을 바탕으로 코드 리팩토링 예정 #8 
- ~~`Swagger` 문서 추가할 예정~~ #7 
- 현재 `mockMvc`를 이용한 테스트코드에 부족함이 많다 느껴져, 다른 기능 테스트 코드를 작성하면서 개선할 예정
